### PR TITLE
Enable entire categories in enabled-problems file

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,9 @@ which is then imported by the main Coding Cat UI.
 # Enabling/disabling problems
 
 The file `enabled-problems` controls which problems actually get build into `problems.js`. It is a
-list of problem names, i.e. strings that appear under the `name` key in `meta.json`.
+list of problem names, or entire categories, i.e. strings that appear under the `name` or `category` key in `meta.json`.
 
 `enable-all-problems` is a script that generates an `enabled-problems` file listing all problems as
 enabled.
+
+If no `enabled-problems` file is defined, every problem is enabled by default.

--- a/build-all
+++ b/build-all
@@ -1,13 +1,36 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+load_name(){ jq -r .name "$1/meta.json"; }
+load_category() { jq -r .category "$1/meta.json"; }
+
+is_enabled(){
+  local name="$1"
+  local category="$2"
+
+  if [[ -f enabled-problems ]]; then
+    grep -qx "$name" enabled-problems && return 0
+    grep -qx "$category" enabled-problems && return 0
+    return 1
+  else
+    return 0
+  fi
+}
+
 for bucket in */; do
   [[ -d "$bucket" ]] || continue
   [[ "${bucket:0:1}" = "." ]] && continue
 
   for prob_dir in "${bucket}"*/; do
-    [[ -d "$prob_dir" ]] || continue
-    echo "building $prob_dir..."
-    ./build-problem "${prob_dir%/}"
+    name=$(load_name "$prob_dir")
+    category=$(load_category "$prob_dir")
+
+    if is_enabled "$name" "$category"; then
+      [[ -d "$prob_dir" ]] || continue
+      echo "building $prob_dir..."
+      ./build-problem "${prob_dir%/}"
+    else
+      echo "skipping $prob_dir..."
+    fi
   done
 done

--- a/build-all
+++ b/build-all
@@ -7,6 +7,7 @@ for bucket in */; do
 
   for prob_dir in "${bucket}"*/; do
     [[ -d "$prob_dir" ]] || continue
+    echo "building $prob_dir..."
     ./build-problem "${prob_dir%/}"
   done
 done

--- a/build-problem-list
+++ b/build-problem-list
@@ -1,14 +1,24 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+echo \n"building problems.js..."
+
 OUTFILE="problems.js"
 TMPFILE="$(mktemp).js"
 
 write(){ echo "$@" >> "$TMPFILE"; }
+
 load_name(){ jq -r .meta.name "$1/problem.json"; }
+load_category() { jq -r .meta.category "$1/problem.json"; }
+
 is_enabled(){
+  local name="$1"
+  local category="$2"
+
   if [[ -f enabled-problems ]]; then
-    grep -qx "$1" enabled-problems
+    grep -qx "$name" enabled-problems && return 0
+    grep -qx "$category" enabled-problems && return 0
+    return 1
   else
     return 0
   fi
@@ -18,8 +28,11 @@ declare -A dir_for_name
 for dir in */*/; do
   [[ -f "${dir}problem.json" ]] || continue
   d=${dir%/}
+
   name=$(load_name "$d")
-  if is_enabled "$name"; then
+  category=$(load_category "$d")
+
+  if is_enabled "$name" "$category"; then
     dir_for_name["$name"]="$d"
   fi
 done

--- a/build-problem-list
+++ b/build-problem-list
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-echo \n"building problems.js..."
+echo -e "\nbuilding problems.js..."
 
 OUTFILE="problems.js"
 TMPFILE="$(mktemp).js"

--- a/clean
+++ b/clean
@@ -2,5 +2,9 @@
 
 # Deletes all build artifacts
 
-rm -f problems.json
-rm */problem.json
+echo "removing all build artifacts..."
+
+rm -f problems.js
+rm **/*/problem.json
+
+echo "successfully removed all problem.json files"


### PR DESCRIPTION
- the enabled-problems file can now take entire categories to be enabled, in addition to individual problems